### PR TITLE
fix(server): don't disable embeddings when macOS misreports 0 MB free

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ with no setup. For the CLI/MCP server it needs a local model directory
 - Distill one from any sentence-transformer (Apache-2.0 Jina-Code by default) in
   ~30 s on CPU: `python scripts/distill_static_model.py`.
 
+#### `CODEGRAPH_SKIP_MEMORY_CHECK` — force the embedding model past the RAM gate
+
+Before loading the ONNX model, the server checks available memory and, if under
+~1.5 GB, skips the model to avoid an OOM-kill (running graph-only instead).
+Set `CODEGRAPH_SKIP_MEMORY_CHECK=1` (also accepts `true`/`yes`) to bypass that
+check and always load the model.
+
+Use it if embeddings are disabled even though the machine has plenty of free
+RAM.
+A reading of `0 MB available` is treated as a detection failure and the model
+loads anyway (macOS parks reclaimable memory in inactive/speculative pages that
+some memory readers do not count as free), so this override is mainly for other
+cases where the reported figure is low but wrong.
+It works in both MCP and one-shot `--run-tool` modes.
+
 #### `--profile` — narrow the MCP tool surface
 
 The full 32-tool surface is convenient but inflates the agent's prompt-context cost. A profile exposes only the slice you need (also settable via the `CODEGRAPH_TOOL_PROFILE` env var):

--- a/crates/codegraph-server/src/ai_query/engine.rs
+++ b/crates/codegraph-server/src/ai_query/engine.rs
@@ -76,6 +76,15 @@ fn available_memory_mb() -> u64 {
     sys.available_memory() / (1024 * 1024)
 }
 
+/// Whether an available-memory reading counts as real pressure for the embed
+/// loop. A 0 MB reading is a detection failure, not genuine pressure — some
+/// macOS `sysinfo` versions report 0 available because reclaimable memory is
+/// not counted as free (issue #13) — so it must not ratchet the batch size
+/// down or force checkpoints.
+fn embed_memory_pressured(avail_mb: u64) -> bool {
+    avail_mb > 0 && avail_mb < EMBED_LOW_MEM_MB
+}
+
 /// Split an identifier into camelCase/snake_case words (deduped, lowercased),
 /// reusing the BM25 tokenizer: `getUserById` -> "get user by id".
 fn split_identifier_words(name: &str) -> String {
@@ -398,7 +407,7 @@ impl QueryEngine {
 
             // RAM backpressure: shed batch size under memory pressure.
             let pressured = chunks_done % EMBED_MEM_CHECK_CHUNKS == 0
-                && available_memory_mb() < EMBED_LOW_MEM_MB;
+                && embed_memory_pressured(available_memory_mb());
             if pressured && chunk_size > 4 {
                 chunk_size = (chunk_size / 2).max(4);
                 tracing::warn!(
@@ -547,7 +556,7 @@ impl QueryEngine {
             chunks_done += 1;
 
             let pressured = chunks_done % EMBED_MEM_CHECK_CHUNKS == 0
-                && available_memory_mb() < EMBED_LOW_MEM_MB;
+                && embed_memory_pressured(available_memory_mb());
             if pressured && chunk_size > 4 {
                 chunk_size = (chunk_size / 2).max(4);
                 tracing::warn!(
@@ -2630,6 +2639,24 @@ mod tests {
         ));
         let engine = QueryEngine::new(Arc::clone(&graph));
         (engine, graph)
+    }
+
+    #[test]
+    fn embed_memory_pressured_low_reading_is_pressure() {
+        assert!(embed_memory_pressured(1));
+        assert!(embed_memory_pressured(EMBED_LOW_MEM_MB - 1));
+    }
+
+    #[test]
+    fn embed_memory_pressured_zero_reading_is_detection_failure_not_pressure() {
+        assert!(!embed_memory_pressured(0));
+    }
+
+    #[test]
+    fn embed_memory_pressured_at_or_above_floor_is_not_pressure() {
+        assert!(!embed_memory_pressured(EMBED_LOW_MEM_MB));
+        assert!(!embed_memory_pressured(EMBED_LOW_MEM_MB + 1));
+        assert!(!embed_memory_pressured(64 * 1024));
     }
 
     #[tokio::test]

--- a/crates/codegraph-server/src/ai_query/engine.rs
+++ b/crates/codegraph-server/src/ai_query/engine.rs
@@ -401,12 +401,12 @@ impl QueryEngine {
             pos = end;
             chunks_done += 1;
 
-            if chunks_done % 10 == 0 && pos < total {
+            if chunks_done.is_multiple_of(10) && pos < total {
                 tracing::info!("[QueryEngine] Embedded {}/{} symbols", pos, total);
             }
 
             // RAM backpressure: shed batch size under memory pressure.
-            let pressured = chunks_done % EMBED_MEM_CHECK_CHUNKS == 0
+            let pressured = chunks_done.is_multiple_of(EMBED_MEM_CHECK_CHUNKS)
                 && embed_memory_pressured(available_memory_mb());
             if pressured && chunk_size > 4 {
                 chunk_size = (chunk_size / 2).max(4);
@@ -555,7 +555,7 @@ impl QueryEngine {
             pos = end;
             chunks_done += 1;
 
-            let pressured = chunks_done % EMBED_MEM_CHECK_CHUNKS == 0
+            let pressured = chunks_done.is_multiple_of(EMBED_MEM_CHECK_CHUNKS)
                 && embed_memory_pressured(available_memory_mb());
             if pressured && chunk_size > 4 {
                 chunk_size = (chunk_size / 2).max(4);
@@ -3991,7 +3991,10 @@ mod tests {
 
     #[test]
     fn split_identifier_words_handles_camel_and_snake() {
-        assert_eq!(split_identifier_words("authenticate_user"), "authenticate user");
+        assert_eq!(
+            split_identifier_words("authenticate_user"),
+            "authenticate user"
+        );
         assert_eq!(split_identifier_words("getUserById"), "get user by id");
         // The existing tokenizer keeps acronym+word runs joined (HTML|Parser is
         // NOT split) and drops 1-char tokens — known limitations worth revisiting
@@ -4013,11 +4016,13 @@ mod tests {
         // Enabled: split name words are front-loaded for the static embedder.
         let with_split =
             QueryEngine::build_embed_text(&node, 0, "getUserById", false, true, &graph);
-        assert!(with_split.starts_with("get user by id"), "got: {with_split}");
+        assert!(
+            with_split.starts_with("get user by id"),
+            "got: {with_split}"
+        );
 
         // Disabled (default): original transformer-path text is unchanged.
-        let without =
-            QueryEngine::build_embed_text(&node, 0, "getUserById", false, false, &graph);
+        let without = QueryEngine::build_embed_text(&node, 0, "getUserById", false, false, &graph);
         assert!(without.starts_with("getUserById"), "got: {without}");
         assert!(!without.contains("get user by id"));
     }

--- a/crates/codegraph-server/src/mcp/engine.rs
+++ b/crates/codegraph-server/src/mcp/engine.rs
@@ -219,10 +219,24 @@ mod imp {
         let shared_engine = {
             let mut sys = sysinfo::System::new();
             sys.refresh_memory();
-            if sys.available_memory() < 1_500_000_000 {
-                tracing::warn!("Engine: <1.5 GB free — running graph-only (no shared model)");
+            let avail = sys.available_memory();
+            let gate = crate::memory::evaluate_memory_gate(
+                avail,
+                crate::memory::MODEL_MIN_FREE_BYTES,
+                crate::memory::memory_check_bypassed(),
+            );
+            if let crate::memory::MemoryGate::Skip(avail) = gate {
+                tracing::warn!(
+                    "Engine: only {} MB available — skipping shared embedding model to avoid OOM; running graph-only. Set CODEGRAPH_SKIP_MEMORY_CHECK=1 to override.",
+                    avail / 1_000_000
+                );
                 None
             } else {
+                if gate == crate::memory::MemoryGate::ProceedDetectionFailed {
+                    tracing::warn!(
+                        "Engine: available memory read as 0 MB — treating as a detection failure (common on macOS, where reclaimable memory is not counted as free) and proceeding with the shared model load. Set CODEGRAPH_SKIP_MEMORY_CHECK=1 to always bypass this check."
+                    );
+                }
                 match VectorEngine::from_backend(model_cache_dir(), &cfg.embedding_model) {
                     Ok(e) => {
                         tracing::info!("Engine: shared embedding model loaded");

--- a/crates/codegraph-server/src/memory.rs
+++ b/crates/codegraph-server/src/memory.rs
@@ -248,7 +248,10 @@ pub struct MemoryManager {
 impl MemoryManager {
     /// Create a new MemoryManager
     pub fn new(extension_path: Option<PathBuf>) -> Self {
-        Self::with_model(extension_path, codegraph_memory::EmbeddingBackend::default())
+        Self::with_model(
+            extension_path,
+            codegraph_memory::EmbeddingBackend::default(),
+        )
     }
 
     /// Create a new MemoryManager with a specific embedding backend
@@ -681,7 +684,10 @@ mod tests {
 
     #[test]
     fn gate_loads_when_ample_memory() {
-        assert_eq!(evaluate_memory_gate(8_000_000_000, MIN, false), MemoryGate::Load);
+        assert_eq!(
+            evaluate_memory_gate(8_000_000_000, MIN, false),
+            MemoryGate::Load
+        );
     }
 
     #[test]
@@ -713,7 +719,10 @@ mod tests {
         // CODEGRAPH_SKIP_MEMORY_CHECK=1 overrides even a genuine low reading.
         assert_eq!(evaluate_memory_gate(0, MIN, true), MemoryGate::Load);
         assert_eq!(evaluate_memory_gate(1, MIN, true), MemoryGate::Load);
-        assert_eq!(evaluate_memory_gate(500_000_000, MIN, true), MemoryGate::Load);
+        assert_eq!(
+            evaluate_memory_gate(500_000_000, MIN, true),
+            MemoryGate::Load
+        );
     }
 
     #[test]

--- a/crates/codegraph-server/src/memory.rs
+++ b/crates/codegraph-server/src/memory.rs
@@ -169,6 +169,62 @@ fn project_data_dir(workspace_path: &Path) -> Result<PathBuf, MemoryError> {
         .join(slug))
 }
 
+/// Minimum available memory to load the ONNX embedding model + runtime
+/// without risking an OOM-kill (a native crash Rust can't catch).
+pub(crate) const MODEL_MIN_FREE_BYTES: u64 = 1_500_000_000; // ~1.5 GB
+
+/// Decision of the pre-model-load RAM gate. Separated from the live sysinfo
+/// reading so the policy is unit-testable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MemoryGate {
+    /// Enough available memory (or the check was bypassed) — load the model.
+    Load,
+    /// Genuinely constrained — skip the model and run graph-only. Carries the
+    /// detected byte count for the log/error message.
+    Skip(u64),
+    /// The available-memory reading was 0, which is a detection failure rather
+    /// than a real state: a running process always holds memory, and on macOS
+    /// reclaimable memory is parked in inactive/speculative/purgeable pages
+    /// that some `sysinfo` versions report as 0 available (issue #13). Proceed
+    /// with the load instead of hard-disabling on a number we don't trust.
+    ProceedDetectionFailed,
+}
+
+/// Decide whether to load the embedding model from the available-memory
+/// reading, the minimum threshold, and whether the user forced a bypass.
+///
+/// Pure: no I/O, no env reads — the caller supplies the inputs. This is the
+/// gate policy; keeping it separate lets tests cover the 0-MB detection-failure
+/// path that can't be reproduced by driving `sysinfo` live.
+pub(crate) fn evaluate_memory_gate(
+    available_bytes: u64,
+    min_free_bytes: u64,
+    bypass: bool,
+) -> MemoryGate {
+    if bypass {
+        return MemoryGate::Load;
+    }
+    if available_bytes == 0 {
+        return MemoryGate::ProceedDetectionFailed;
+    }
+    if available_bytes < min_free_bytes {
+        return MemoryGate::Skip(available_bytes);
+    }
+    MemoryGate::Load
+}
+
+/// Whether the user forced the RAM gate off via `CODEGRAPH_SKIP_MEMORY_CHECK`
+/// (`1`/`true`/`yes`, case-insensitive). The escape hatch works in both MCP and
+/// one-shot `--run-tool` modes since it is read at model-load time.
+pub(crate) fn memory_check_bypassed() -> bool {
+    std::env::var("CODEGRAPH_SKIP_MEMORY_CHECK")
+        .map(|v| {
+            let v = v.trim();
+            v == "1" || v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("yes")
+        })
+        .unwrap_or(false)
+}
+
 /// Memory manager for the LSP server
 ///
 /// Opens the database on-demand for each operation and closes it immediately after.
@@ -284,21 +340,30 @@ impl MemoryManager {
             let mut sys = sysinfo::System::new();
             sys.refresh_memory();
             let avail = sys.available_memory();
-            const MIN_FREE_BYTES: u64 = 1_500_000_000; // ~1.5 GB for model + ort runtime
             tracing::info!(
                 "[MemoryManager::initialize] available memory: {} MB",
                 avail / 1_000_000
             );
-            if avail < MIN_FREE_BYTES {
-                crate::crash_phase::mark("onnx_skipped_lowmem");
-                tracing::warn!(
-                    "[MemoryManager::initialize] only {} MB free — skipping embedding model to avoid OOM; semantic search disabled (graph-only)",
-                    avail / 1_000_000
-                );
-                return Err(MemoryError::Other(format!(
-                    "insufficient memory ({} MB free) to load embedding model; running graph-only",
-                    avail / 1_000_000
-                )));
+            match evaluate_memory_gate(avail, MODEL_MIN_FREE_BYTES, memory_check_bypassed()) {
+                MemoryGate::Skip(avail) => {
+                    crate::crash_phase::mark("onnx_skipped_lowmem");
+                    tracing::warn!(
+                        "[MemoryManager::initialize] only {} MB available — skipping embedding model to avoid OOM; semantic search disabled (graph-only). Set CODEGRAPH_SKIP_MEMORY_CHECK=1 to override.",
+                        avail / 1_000_000
+                    );
+                    return Err(MemoryError::Other(format!(
+                        "insufficient memory ({} MB available) to load embedding model; running graph-only (set CODEGRAPH_SKIP_MEMORY_CHECK=1 to override)",
+                        avail / 1_000_000
+                    )));
+                }
+                MemoryGate::ProceedDetectionFailed => {
+                    // 0 MB is a detection failure (see MemoryGate) — don't
+                    // disable embeddings on a Mac that actually has RAM.
+                    tracing::warn!(
+                        "[MemoryManager::initialize] available memory read as 0 MB — treating as a detection failure (common on macOS, where reclaimable memory is not counted as free) and proceeding with the embedding model load. Set CODEGRAPH_SKIP_MEMORY_CHECK=1 to always bypass this check."
+                    );
+                }
+                MemoryGate::Load => {}
             }
         }
 
@@ -611,6 +676,45 @@ pub use codegraph_memory::{
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const MIN: u64 = MODEL_MIN_FREE_BYTES;
+
+    #[test]
+    fn gate_loads_when_ample_memory() {
+        assert_eq!(evaluate_memory_gate(8_000_000_000, MIN, false), MemoryGate::Load);
+    }
+
+    #[test]
+    fn gate_loads_exactly_at_threshold() {
+        // `< min` is the skip condition, so exactly `min` must load.
+        assert_eq!(evaluate_memory_gate(MIN, MIN, false), MemoryGate::Load);
+    }
+
+    #[test]
+    fn gate_skips_when_genuinely_low() {
+        assert_eq!(
+            evaluate_memory_gate(500_000_000, MIN, false),
+            MemoryGate::Skip(500_000_000)
+        );
+    }
+
+    #[test]
+    fn gate_proceeds_on_zero_reading_as_detection_failure() {
+        // The issue-13 case: sysinfo reports 0 available on a healthy Mac.
+        // 0 is never a real state, so proceed rather than disable embeddings.
+        assert_eq!(
+            evaluate_memory_gate(0, MIN, false),
+            MemoryGate::ProceedDetectionFailed
+        );
+    }
+
+    #[test]
+    fn gate_bypass_forces_load_regardless_of_reading() {
+        // CODEGRAPH_SKIP_MEMORY_CHECK=1 overrides even a genuine low reading.
+        assert_eq!(evaluate_memory_gate(0, MIN, true), MemoryGate::Load);
+        assert_eq!(evaluate_memory_gate(1, MIN, true), MemoryGate::Load);
+        assert_eq!(evaluate_memory_gate(500_000_000, MIN, true), MemoryGate::Load);
+    }
 
     #[test]
     fn generation_zero_maps_to_historical_path() {

--- a/mcp-package/README.md
+++ b/mcp-package/README.md
@@ -54,6 +54,11 @@ Pass flags after `--`:
 | `--graph-only` | off | Skip embeddings — graph + structural tools only. No ONNX model load, 10-50× faster indexing. For CI / one-shot graph queries. |
 | `--run-tool <name>` | — | One-shot: index, run a single tool, print result, exit. No MCP handshake. Pair with `--tool-args '<json>'`. |
 
+Before loading the ONNX embedding model, the server checks available memory and runs graph-only if under ~1.5 GB.
+If embeddings are disabled even though the machine has plenty of free RAM, set `CODEGRAPH_SKIP_MEMORY_CHECK=1` (also accepts `true`/`yes`) to bypass the check.
+A reading of `0 MB available` is treated as a detection failure and the model loads anyway (common on macOS).
+Works in both MCP and one-shot `--run-tool` modes.
+
 ### Agent rules (recommended)
 
 Pre-configured rule files that teach your AI agent to use CodeGraph tools before falling back to grep / multi-file reads:


### PR DESCRIPTION
## Intent

The developer asked the agent to investigate a user-reported GitHub issue (#13) on the CodeGraph repo where the server disabled embeddings/model loading because macOS misreported 0 MB of available memory via sysinfo's available_memory(). They wanted the gate fixed so a 0 MB reading is treated as a detection failure that proceeds with the model load, plus a CODEGRAPH_SKIP_MEMORY_CHECK environment-variable escape hatch, with unit tests covering the load/skip/zero/bypass/boundary cases. They explicitly asked to document CODEGRAPH_SKIP_MEMORY_CHECK in the README. Finally, they instructed the agent to post the drafted resolution comment on issue #13 and push the fix/macos-memory-detection branch (through the no-mistakes validation gate rather than directly to origin), noting the fix would need to be folded into the latest code currently in testing. This work sat alongside broader session efforts (VS Code extension funnel/CodeLens features, vsix packaging, and userbase-growth planning) but the commit itself was the isolated macOS memory-detection fix off main.

## What Changed

- Extracted the pre-model-load RAM gate into a pure, unit-tested `evaluate_memory_gate` policy in `crates/codegraph-server/src/memory.rs`: a 0-byte `available_memory()` reading is now treated as a detection failure (common on macOS, issue #13) and the ONNX embedding model loads anyway, instead of hard-disabling semantic search; genuinely low readings still skip the model with a graph-only fallback.
- Added a `CODEGRAPH_SKIP_MEMORY_CHECK` env-var escape hatch to bypass the gate entirely, referenced in the skip-path log/error messages and documented in both the main README and the npm `mcp-package` README.
- Applied the same shared gate to the socket-engine shared-model path (`mcp/engine.rs`) and taught the embed-loop RAM backpressure (`ai_query/engine.rs`) to ignore 0 MB readings, so misreporting machines no longer fall back to per-workspace model loads or permanently ratchet batch size down to the minimum. Covered by new gate/backpressure unit tests plus e2e runs against a fake vm_stats shim exercising the zero, low, and bypass paths (all passing in the pipeline).

## Risk Assessment

✅ Low: Well-bounded fix with the gate policy extracted into a pure, unit-tested helper, both previously flagged inconsistent call sites (socket-engine gate and embed backpressure) now correctly reusing it, no remaining raw memory checks, and README documentation matching actual behavior.

## Testing

Ran all 8 new unit tests (gate policy load/skip/zero/bypass/boundary plus embed-backpressure zero-reading cases; all pass), then exercised the fix end-to-end by running the real codegraph-server binary with a DYLD interpose shim that reproduces sysinfo's macOS 0 MB misreport: the 0 MB case now proceeds to load the embedding model (one-shot and --serve engine paths), genuinely low memory still skips with the new override hint, and CODEGRAPH_SKIP_MEMORY_CHECK=1 bypasses the gate live; log transcripts and the shim source are saved as evidence. No UI surface is involved, so log transcripts are the reviewer-visible artifact.

<details>
<summary>Evidence: Memory-gate e2e log transcript (baseline / 0 MB repro / low-skip / bypass / socket engine)</summary>

```text
# macOS memory-gate fix (issue #13) - end-to-end verification

Real 'codegraph-server' debug binary run on macOS. The 0 MB / low-memory
readings are injected by a DYLD interpose shim on host_statistics64 that
reproduces the exact sysinfo failure mode (compressor pages exceed
free+inactive+purgeable, so the saturating subtraction yields 0).

## 1. Baseline (no shim): healthy Mac, model loads
`` `
2026-07-19T04:44:01.171550Z  INFO codegraph_server::memory: [MemoryManager::initialize] available memory: 6951 MB
2026-07-19T04:44:01.171734Z  INFO codegraph_memory::embedding::fastembed_embed: Loading embedding model: BGE-Small-EN-v1.5 (384d, 512-tok context)
2026-07-19T04:44:01.317533Z  INFO codegraph_server::memory: [MemoryManager::initialize] Memory initialized at "/Users/anvanster/.codegraph/projects/cg-memgate-ws-qcwm-4997/memory"
`` `

## 2. Issue #13 repro: sysinfo reports 0 MB -> detection failure, model STILL loads (the fix)
`` `
2026-07-19T04:45:17.290998Z  INFO codegraph_server::memory: [MemoryManager::initialize] available memory: 0 MB
2026-07-19T04:45:17.291005Z  WARN codegraph_server::memory: [MemoryManager::initialize] available memory read as 0 MB — treating as a detection failure (common on macOS, where reclaimable memory is not counted as free) and proceeding with the embedding model load. Set CODEGRAPH_SKIP_MEMORY_CHECK=1 to always bypass this check.
2026-07-19T04:45:17.291065Z  INFO codegraph_memory::embedding::fastembed_embed: Loading embedding model: BGE-Small-EN-v1.5 (384d, 512-tok context)
2026-07-19T04:45:17.409268Z  INFO codegraph_server::memory: [MemoryManager::initialize] Memory initialized at "/Users/anvanster/.codegraph/projects/cg-memgate-ws-qcwm-4997/memory"
`` `

## 3. Genuinely low memory (499 MB) -> model skipped, graph-only, override hint shown
`` `
2026-07-19T04:45:24.374805Z  INFO codegraph_server::memory: [MemoryManager::initialize] available memory: 499 MB
2026-07-19T04:45:24.374853Z  WARN codegraph_server::memory: [MemoryManager::initialize] only 499 MB available — skipping embedding model to avoid OOM; semantic search disabled (graph-only). Set CODEGRAPH_SKIP_MEMORY_CHECK=1 to override.
2026-07-19T04:45:24.374866Z  WARN codegraph_server::mcp::server: Failed to initialize memory manager: Other("insufficient memory (499 MB available) to load embedding model; running graph-only (set CODEGRAPH_SKIP_MEMORY_CHECK=1 to override)")
`` `

## 4. Low memory + CODEGRAPH_SKIP_MEMORY_CHECK=1 -> bypass, model loads anyway
`` `
2026-07-19T04:45:30.272221Z  INFO codegraph_server::memory: [MemoryManager::initialize] available memory: 499 MB
2026-07-19T04:45:30.272282Z  INFO codegraph_memory::embedding::fastembed_embed: Loading embedding model: BGE-Small-EN-v1.5 (384d, 512-tok context)
2026-07-19T04:45:30.390570Z  INFO codegraph_server::memory: [MemoryManager::initialize] Memory initialized at "/Users/anvanster/.codegraph/projects/cg-memgate-ws-qcwm-4997/memory"
`` `

## 5. Resident socket engine (--serve) with 0 MB reading -> shared model still loads
`` `
2026-07-19T04:45:42.638473Z  WARN codegraph_server::mcp::engine::imp: Engine: available memory read as 0 MB — treating as a detection failure (common on macOS, where reclaimable memory is not counted as free) and proceeding with the shared model load. Set CODEGRAPH_SKIP_MEMORY_CHECK=1 to always bypass this check.
2026-07-19T04:45:42.787735Z  INFO codegraph_server::mcp::engine::imp: Engine: shared embedding model loaded
2026-07-19T04:45:46.792230Z  INFO codegraph_server::mcp::engine::imp: Engine: idle 3s with no clients — shutting down
`` `
```
</details>
<details>
<summary>Evidence: DYLD interpose shim used to reproduce the macOS 0 MB sysinfo misreport</summary>

`Interposes host_statistics64 and inflates compressor_page_count so sysinfo's (free+inactive+purgeable - compressor) saturating subtraction yields 0 — the exact issue-13 failure mode; FAKE_VM_MODE=low fakes ~500 MB for the skip/bypass paths.`

```text
#include <mach/mach.h>
#include <stdlib.h>
#include <unistd.h>

// Interpose host_statistics64 to simulate the macOS condition from
// CodeGraph issue #13: the compressor holds more pages than
// free+inactive+purgeable, so sysinfo's saturating subtraction yields
// 0 bytes "available" on a machine that actually has plenty of RAM.
static kern_return_t my_host_statistics64(host_t host, host_flavor_t flavor,
                                          host_info64_t info,
                                          mach_msg_type_number_t *count) {
    kern_return_t r = host_statistics64(host, flavor, info, count);
    if (flavor == HOST_VM_INFO64 && r == KERN_SUCCESS) {
        vm_statistics64_data_t *vm = (vm_statistics64_data_t *)info;
        const char *mode = getenv("FAKE_VM_MODE");
        if (mode && mode[0] == 'z') {
            // free+inactive+purgeable - compressor saturates to 0
            vm->compressor_page_count =
                vm->free_count + vm->inactive_count + vm->purgeable_count + 1000;
        } else if (mode && mode[0] == 'l') {
            // genuinely low: ~500 MB available
            long pgsz = sysconf(_SC_PAGESIZE);
            vm->free_count = (natural_t)(500000000ULL / (unsigned long long)pgsz);
            vm->inactive_count = 0;
            vm->purgeable_count = 0;
            vm->compressor_page_count = 0;
        }
    }
    return r;
}

__attribute__((used)) static struct {
    const void *repl;
    const void *orig;
} interposers[] __attribute__((section("__DATA,__interpose"))) = {
    {(const void *)my_host_statistics64, (const void *)host_statistics64},
};
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `crates/codegraph-server/src/mcp/engine.rs:222` - The socket-engine shared-model gate still uses the raw `sys.available_memory() &lt; 1_500_000_000` check with no zero-reading (detection-failure) handling and no CODEGRAPH_SKIP_MEMORY_CHECK support, despite its comment saying it gates &#39;the same way the per-workspace path does&#39;. On a macOS machine misreporting 0 MB (issue #13), the shared model is skipped and every workspace falls back to loading its own ONNX model via the now-fixed per-workspace gate - multiplying memory usage on exactly the machines flagged as constrained, and making the README claim that the env var works in MCP mode only accidentally true. Fix by reusing evaluate_memory_gate, memory_check_bypassed, and MODEL_MIN_FREE_BYTES here (they are already pub(crate)).
- ⚠️ `crates/codegraph-server/src/ai_query/engine.rs:401` - The embed-loop RAM backpressure (also at line 550) treats a 0 MB available_memory reading as genuine pressure: on the same misreporting macOS machines, every poll of `available_memory_mb() &lt; EMBED_LOW_MEM_MB` is true, so the ONNX batch size ratchets down to the minimum of 4 and a checkpoint is forced on every poll, permanently degrading embedding throughput during first index. Apply the same &#39;0 is an untrusted reading, not real state&#39; rule introduced by this commit (e.g. `avail_mb &gt; 0 &amp;&amp; avail_mb &lt; EMBED_LOW_MEM_MB`).

🔧 Fix: apply shared memory gate to socket engine and embed backpressure
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo test -p codegraph-server --lib gate_ (5 MemoryGate policy tests: ample/boundary/low-skip/zero/bypass — all pass)`
- `cargo test -p codegraph-server --lib embed_memory_pressured (3 embed-backpressure tests incl. zero-reading-not-pressure — all pass)`
- `cargo test -p codegraph-server --lib memory:: (full memory module suite — 26 pass, 1 ignored needing model files)`
- `Baseline e2e: RUST_LOG=info ./target/debug/codegraph-server --workspace <tmp> --run-tool codegraph_get_symbol_info — 6951 MB read, model loads normally`
- `Issue #13 e2e repro: same command under DYLD_INSERT_LIBRARIES=fake_vm_stats.dylib FAKE_VM_MODE=zero — sysinfo reads 0 MB, server logs detection-failure warning and still loads the embedding model`
- `Skip-path e2e: FAKE_VM_MODE=low (499 MB) — model skipped, graph-only, log and error now carry the CODEGRAPH_SKIP_MEMORY_CHECK=1 override hint`
- `Bypass e2e: FAKE_VM_MODE=low CODEGRAPH_SKIP_MEMORY_CHECK=1 — model loads despite 499 MB reading`
- `Socket-engine e2e: ./target/debug/codegraph-server --serve under FAKE_VM_MODE=zero — 'Engine:' detection-failure warning logged and shared embedding model loaded`
- `Confirmed README diff documents CODEGRAPH_SKIP_MEMORY_CHECK and worktree left clean after testing`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
