### PR TITLE
fix(release): correct npm package metadata and gate publishing on engine assets

### DIFF
--- a/mcp-package/package.json
+++ b/mcp-package/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codegraph-ai/CodeGraph"
+    "url": "git+https://github.com/codegraph-ai/CodeGraph.git"
   },
   "keywords": [
     "mcp",
@@ -20,10 +20,10 @@
     "copilot"
   ],
   "bin": {
-    "codegraph-mcp": "./bin/codegraph-mcp.js",
-    "codegraph-daemon": "./bin/codegraph-daemon.js",
-    "codegraph-mcp-install-hooks": "./bin/install-hooks.js",
-    "codegraph-mcp-fetch-engine": "./bin/fetch-engine-cli.js"
+    "codegraph-mcp": "bin/codegraph-mcp.js",
+    "codegraph-daemon": "bin/codegraph-daemon.js",
+    "codegraph-mcp-install-hooks": "bin/install-hooks.js",
+    "codegraph-mcp-fetch-engine": "bin/fetch-engine-cli.js"
   },
   "files": [
     "bin/",

--- a/scripts/package-npm.sh
+++ b/scripts/package-npm.sh
@@ -7,8 +7,9 @@
 #
 # The engine is not bundled: it is fetched from the GitHub release at install
 # time by bin/postinstall.js. Publish the release assets first with
-# ./scripts/publish-release-assets.sh, or installs of this version will fail to
-# find an engine.
+# ./scripts/publish-release-assets.sh - this script refuses to pack until every
+# asset for the pinned engine version is on the release, because an install
+# without them succeeds and then has nothing to run.
 #
 # Usage:
 #   ./scripts/package-npm.sh           # pack only

--- a/scripts/package-npm.sh
+++ b/scripts/package-npm.sh
@@ -53,11 +53,26 @@ fi
 echo "  ✓ package tests pass"
 
 # Step 3: Verify version consistency
+#
+# server.json carries the release version twice: once at the top level, and once
+# inside the npm entry of `packages`, which is the field the MCP Registry
+# resolves the tarball from. Nothing synchronises the three numbers - they are
+# hand-edited - so all of them are compared, not just the top-level one. A
+# release that bumped package.json and server.json but missed the nested version
+# would register a new server entry pointing at the previous tarball, and the
+# Registry would accept it because that older tarball exists and carries the
+# right mcpName.
 PKG_VERSION=$(node -e "console.log(require('$PKG_DIR/package.json').version)")
 SERVER_VERSION=$(node -e "console.log(require('$PKG_DIR/server.json').version)")
+SERVER_NPM_VERSION=$(node -e "
+  const npm = (require('$PKG_DIR/server.json').packages || [])
+    .find((p) => p.registryType === 'npm');
+  console.log(npm ? npm.version : '<no npm package entry>');
+")
 echo ""
-echo "package.json version: $PKG_VERSION"
-echo "server.json version:  $SERVER_VERSION"
+echo "package.json version:      $PKG_VERSION"
+echo "server.json version:       $SERVER_VERSION"
+echo "server.json npm package:   $SERVER_NPM_VERSION"
 
 # A mismatch here is fatal rather than a warning. The two files are published to
 # two different registries under one version, and a warning scrolls past in the
@@ -67,19 +82,61 @@ if [ "$PKG_VERSION" != "$SERVER_VERSION" ]; then
   echo "ERROR: version mismatch between package.json ($PKG_VERSION) and server.json ($SERVER_VERSION)" >&2
   exit 1
 fi
-
-# The npm package contains no engine; every install fetches one from the release
-# tagged with this version. Publishing before those assets exist produces a
-# package that installs cleanly and then has nothing to run.
-ENGINE_VERSION=$(node -e "console.log(require('$PKG_DIR/bin/fetch-engine').ENGINE_VERSION)")
-echo "engine version:       $ENGINE_VERSION (fetched at install time)"
-if ! curl -fsSL -o /dev/null \
-  "https://github.com/codegraph-ai/CodeGraph/releases/download/v${ENGINE_VERSION}/codegraph-server-linux-x64.sha256"; then
-  echo "ERROR: no published engine assets for v${ENGINE_VERSION}" >&2
-  echo "  Run ./scripts/publish-release-assets.sh first, or installs will find no engine." >&2
+if [ "$PKG_VERSION" != "$SERVER_NPM_VERSION" ]; then
+  echo "ERROR: version mismatch between package.json ($PKG_VERSION) and the npm entry in server.json ($SERVER_NPM_VERSION)" >&2
+  echo "  The MCP Registry resolves the tarball from packages[].version, so this would" >&2
+  echo "  publish a $PKG_VERSION server entry pointing at the $SERVER_NPM_VERSION tarball." >&2
   exit 1
 fi
-echo "  ✓ engine assets are published for v${ENGINE_VERSION}"
+
+# The npm package contains no engine; every install fetches one from the release
+# tagged with the engine version pinned in bin/fetch-engine.js, which is
+# deliberately not this package's version (see the ENGINE_VERSION comment there:
+# a client-only patch release must not start asking for a tag nobody published).
+# Publishing before those assets exist produces a package that installs cleanly
+# and then has nothing to run.
+#
+# Every asset is probed, not just one. publish-release-assets.sh uploads the
+# whole staging directory in a single `gh release upload`, so a network drop or
+# a rate limit part-way through leaves the release with some platforms attached
+# and others missing - and a one-platform probe would wave that through, giving
+# users on the missing platforms exactly the empty install this gate exists to
+# prevent. The list mirrors BINARIES + WINDOWS_SIDECAR there, which is the same
+# set bin/fetch-engine.js resolves against.
+ENGINE_VERSION=$(node -e "console.log(require('$PKG_DIR/bin/fetch-engine').ENGINE_VERSION)")
+ENGINE_ASSETS=(
+  "codegraph-server-darwin-arm64"
+  "codegraph-server-darwin-x64"
+  "codegraph-server-linux-x64"
+  "codegraph-server-win32-x64.exe"
+  "onnxruntime.dll"
+)
+RELEASE_BASE="https://github.com/codegraph-ai/CodeGraph/releases/download/v${ENGINE_VERSION}"
+
+echo ""
+echo "engine version:            $ENGINE_VERSION (fetched at install time)"
+echo "Checking published engine assets for v${ENGINE_VERSION}..."
+missing_assets=0
+for asset in "${ENGINE_ASSETS[@]}"; do
+  # A binary and its checksum are separate assets and the client needs both, so
+  # both are probed. The binaries are requested one byte at a time - presence is
+  # the question here, and downloading ~120 MB to answer it is not worth it.
+  if ! curl -fsSL -o /dev/null -r 0-0 "$RELEASE_BASE/$asset" \
+    || ! curl -fsSL -o /dev/null "$RELEASE_BASE/$asset.sha256"; then
+    printf '  ✗ %s\n' "$asset"
+    missing_assets=1
+  else
+    printf '  ✓ %s\n' "$asset"
+  fi
+done
+
+if [ "$missing_assets" -ne 0 ]; then
+  echo "ERROR: the release v${ENGINE_VERSION} is missing engine assets (binary or .sha256)." >&2
+  echo "  Run ./scripts/publish-release-assets.sh --publish first, or installs on those" >&2
+  echo "  platforms will find no engine." >&2
+  exit 1
+fi
+echo "  ✓ every engine asset is published for v${ENGINE_VERSION}"
 
 # Step 4: Pack
 echo ""

--- a/scripts/package-npm.sh
+++ b/scripts/package-npm.sh
@@ -5,7 +5,6 @@
 # Package the npm MCP server distribution.
 # Run from the repo root after all platform binaries are built.
 #
-# Usage:
 # The engine is not bundled: it is fetched from the GitHub release at install
 # time by bin/postinstall.js. Publish the release assets first with
 # ./scripts/publish-release-assets.sh, or installs of this version will fail to
@@ -60,9 +59,27 @@ echo ""
 echo "package.json version: $PKG_VERSION"
 echo "server.json version:  $SERVER_VERSION"
 
+# A mismatch here is fatal rather than a warning. The two files are published to
+# two different registries under one version, and a warning scrolls past in the
+# npm pack output - leaving npmjs.com and the MCP Registry disagreeing about what
+# this release is, which cannot be corrected by republishing the same version.
 if [ "$PKG_VERSION" != "$SERVER_VERSION" ]; then
-  echo "WARNING: version mismatch between package.json and server.json"
+  echo "ERROR: version mismatch between package.json ($PKG_VERSION) and server.json ($SERVER_VERSION)" >&2
+  exit 1
 fi
+
+# The npm package contains no engine; every install fetches one from the release
+# tagged with this version. Publishing before those assets exist produces a
+# package that installs cleanly and then has nothing to run.
+ENGINE_VERSION=$(node -e "console.log(require('$PKG_DIR/bin/fetch-engine').ENGINE_VERSION)")
+echo "engine version:       $ENGINE_VERSION (fetched at install time)"
+if ! curl -fsSL -o /dev/null \
+  "https://github.com/codegraph-ai/CodeGraph/releases/download/v${ENGINE_VERSION}/codegraph-server-linux-x64.sha256"; then
+  echo "ERROR: no published engine assets for v${ENGINE_VERSION}" >&2
+  echo "  Run ./scripts/publish-release-assets.sh first, or installs will find no engine." >&2
+  exit 1
+fi
+echo "  ✓ engine assets are published for v${ENGINE_VERSION}"
 
 # Step 4: Pack
 echo ""


### PR DESCRIPTION
## Intent

The developer was finishing the 0.20.0 release of CodeGraph across all three distribution channels (GitHub release binaries, the npm package @astudioplus/codegraph-mcp, and the MCP Registry) and asked the agent to double-check scripts/package-npm.sh for correctness before running it manually, since npmjs 2FA meant the developer had to execute the publish themselves. During the actual publish, npm emitted warnings that it had auto-corrected package.json - the four bin entries were declared with a "./bin/..." prefix that npm rejected and normalized, and repository.url was normalized to "git+https://github.com/codegraph-ai/CodeGraph.git" - so the developer aborted the publish and asked for those metadata errors to be fixed in the scripts before retrying. The intent was to make the published npm metadata match exactly what npm expects so publishing runs clean with no warnings, and to harden the packaging script itself: a version mismatch between package.json and server.json should be fatal rather than a printed warning, and the script should verify the GitHub release engine assets exist before publishing, since the package ships no bundled engine and an install would otherwise succeed with nothing to run. The developer explicitly did not want a version bump (0.20.0 had in fact published successfully; only the follow-on MCP Registry step had failed on auth). Finally the developer asked to commit the two changed files - mcp-package/package.json and scripts/package-npm.sh - so the repository would record the metadata that actually produced the live 0.20.0 release, and then to push, which per their setup goes through the no-mistakes gate rather than directly to origin.

## What Changed

- `mcp-package/package.json`: the four `bin` entries drop their `./` prefix and `repository.url` becomes `git+https://github.com/codegraph-ai/CodeGraph.git`, so the published metadata matches what npm normalizes to instead of being auto-corrected with warnings at publish time.
- `scripts/package-npm.sh`: a version mismatch is now fatal instead of a printed warning, and the check covers `server.json`'s nested `packages[].version` (the field the MCP Registry resolves the tarball from) in addition to the top-level `version`.
- `scripts/package-npm.sh`: before packing, the script probes the GitHub release for the engine version pinned in `bin/fetch-engine.js` and fails if any of the five engine assets or their `.sha256` files are missing, since the package bundles no engine and an install would otherwise succeed with nothing to run. Header comments were updated to describe the new gate. A follow-up note from review: the probes have no `curl --retry`, so a transient network failure reports a complete release as missing (fail-closed, re-runnable).

## Risk Assessment

✅ Low: All three round-1 findings are correctly fixed and the change remains confined to release tooling plus npm metadata that matches npm's own normalization, with the asset list verified to mirror publish-release-assets.sh exactly and the stricter gate confirmed to pass against the live v0.20.0 release.

## Testing

Ran the mcp-package test suite (the same suite the packaging script gates on) plus targeted end-to-end verification of the actual user-visible intent: `npm publish --dry-run` reproduces the five auto-correction warnings on the base commit's package.json and emits none on the fixed one; the committed bin map and repository.url match exactly what npmjs.com stores for the live 0.20.0 release; and installing the packed tarball creates all four working bin shims. Exercised the packaging script in temp repo copies - the happy path probes the real v0.20.0 GitHub release and finds all five engine assets with their checksums (exit 0), while a server.json top-level mismatch, a packages[].version mismatch, and an unpublished engine version each abort with exit 1, versus the base script which warned and packaged anyway at exit 0. This change is CLI/packaging-only with no rendered UI surface, so the evidence is publish transcripts and install output rather than screenshots. Everything passed; the worktree was left clean with no stray tarballs or binaries.

<details>
<summary>Evidence: npm publish --dry-run BEFORE (base commit metadata) - the aborted-publish warnings</summary>

<code>npm warn publish npm auto-corrected some errors in your package.json when publishing. Please run &#34;npm pkg fix&#34; to address these errors.&#10;npm warn publish errors corrected:&#10;npm warn publish &#34;bin[codegraph-mcp]&#34; script name bin/codegraph-mcp.js was invalid and removed&#10;npm warn publish &#34;bin[codegraph-daemon]&#34; script name bin/codegraph-daemon.js was invalid and removed&#10;npm warn publish &#34;bin[codegraph-mcp-install-hooks]&#34; script name bin/install-hooks.js was invalid and removed&#10;npm warn publish &#34;bin[codegraph-mcp-fetch-engine]&#34; script name bin/fetch-engine-cli.js was invalid and removed&#10;npm warn publish &#34;repository.url&#34; was normalized to &#34;git+https://github.com/codegraph-ai/CodeGraph.git&#34;</code>

```text
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "bin[codegraph-mcp]" script name bin/codegraph-mcp.js was invalid and removed
npm warn publish "bin[codegraph-daemon]" script name bin/codegraph-daemon.js was invalid and removed
npm warn publish "bin[codegraph-mcp-install-hooks]" script name bin/install-hooks.js was invalid and removed
npm warn publish "bin[codegraph-mcp-fetch-engine]" script name bin/fetch-engine-cli.js was invalid and removed
npm warn publish "repository.url" was normalized to "git+https://github.com/codegraph-ai/CodeGraph.git"
npm notice
npm notice 📦  @astudioplus/codegraph-mcp@0.20.0
npm notice Tarball Contents
npm notice 7.3kB README.md
npm notice 6.0kB bin/codegraph-daemon.js
npm notice 11.5kB bin/codegraph-mcp.js
npm notice 1.9kB bin/fetch-engine-cli.js
npm notice 17.0kB bin/fetch-engine.js
npm notice 8.6kB bin/install-hooks.js
npm notice 5.9kB bin/postinstall.js
npm notice 4.6kB hooks/codegraph-pre-edit.ps1
npm notice 3.9kB hooks/codegraph-pre-edit.sh
npm notice 1.2kB package.json
npm notice 606B server.json
npm notice Tarball Details
npm notice name: @astudioplus/codegraph-mcp
npm notice version: 0.20.0
npm notice filename: astudioplus-codegraph-mcp-0.20.0.tgz
npm notice package size: 22.2 kB
npm notice unpacked size: 68.5 kB
npm notice shasum: 2fd3105a532e3190bc7f4804f521cf5de0be30cd
npm notice integrity: sha512-fQB32vWGXpdth[...]CjlgfYM5Kzf9A==
npm notice total files: 11
npm notice
npm error You cannot publish over the previously published versions: 0.20.0.
npm error A complete log of this run can be found in: /Users/anvanster/.npm/_logs/2026-08-09T05_03_38_909Z-debug-0.log
```
</details>
<details>
<summary>Evidence: npm publish --dry-run AFTER (fixed metadata) - no warnings, clean manifest</summary>

<code>npm notice 📦 @astudioplus/codegraph-mcp@0.20.0&#10;npm notice ... (11 files)&#10;npm notice name: @astudioplus/codegraph-mcp&#10;npm notice version: 0.20.0&#10;npm notice filename: astudioplus-codegraph-mcp-0.20.0.tgz&#10;npm notice package size: 22.2 kB&#10;&#10;(zero `npm warn publish` lines; the only error is the expected&#10;&#34;You cannot publish over the previously published versions: 0.20.0&#34;,&#10;since 0.20.0 is already live)</code>

```text
npm notice
npm notice 📦  @astudioplus/codegraph-mcp@0.20.0
npm notice Tarball Contents
npm notice 7.3kB README.md
npm notice 6.0kB bin/codegraph-daemon.js
npm notice 11.5kB bin/codegraph-mcp.js
npm notice 1.9kB bin/fetch-engine-cli.js
npm notice 17.0kB bin/fetch-engine.js
npm notice 8.6kB bin/install-hooks.js
npm notice 5.9kB bin/postinstall.js
npm notice 4.6kB hooks/codegraph-pre-edit.ps1
npm notice 3.9kB hooks/codegraph-pre-edit.sh
npm notice 1.2kB package.json
npm notice 606B server.json
npm notice Tarball Details
npm notice name: @astudioplus/codegraph-mcp
npm notice version: 0.20.0
npm notice filename: astudioplus-codegraph-mcp-0.20.0.tgz
npm notice package size: 22.2 kB
npm notice unpacked size: 68.5 kB
npm notice shasum: e0bfca866c1cedf446f6a2e06d1786b38da8b49e
npm notice integrity: sha512-/X6vyxOPv4VLc[...]BQ8pob73ipfFw==
npm notice total files: 11
npm notice
npm error You cannot publish over the previously published versions: 0.20.0.
npm error A complete log of this run can be found in: /Users/anvanster/.npm/_logs/2026-08-09T05_03_10_898Z-debug-0.log
```
</details>
<details>
<summary>Evidence: Committed package.json matches the live 0.20.0 registry metadata</summary>

<code># npm view @astudioplus/codegraph-mcp@0.20.0 bin repository.url&#10;bin = {&#10;&#39;codegraph-mcp&#39;: &#39;bin/codegraph-mcp.js&#39;,&#10;&#39;codegraph-daemon&#39;: &#39;bin/codegraph-daemon.js&#39;,&#10;&#39;codegraph-mcp-install-hooks&#39;: &#39;bin/install-hooks.js&#39;,&#10;&#39;codegraph-mcp-fetch-engine&#39;: &#39;bin/fetch-engine-cli.js&#39;&#10;}&#10;repository.url = &#39;git+https://github.com/codegraph-ai/CodeGraph.git&#39;&#10;&#10;# mcp-package/package.json now records the identical values.</code>

```text
# What npmjs.com actually stores for the live 0.20.0 release
bin = {
  'codegraph-mcp': 'bin/codegraph-mcp.js',
  'codegraph-daemon': 'bin/codegraph-daemon.js',
  'codegraph-mcp-install-hooks': 'bin/install-hooks.js',
  'codegraph-mcp-fetch-engine': 'bin/fetch-engine-cli.js'
}
repository.url = 'git+https://github.com/codegraph-ai/CodeGraph.git'

# What mcp-package/package.json now records
{
  "bin": {
    "codegraph-mcp": "bin/codegraph-mcp.js",
    "codegraph-daemon": "bin/codegraph-daemon.js",
    "codegraph-mcp-install-hooks": "bin/install-hooks.js",
    "codegraph-mcp-fetch-engine": "bin/fetch-engine-cli.js"
  },
  "repository.url": "git+https://github.com/codegraph-ai/CodeGraph.git"
}
```
</details>
<details>
<summary>Evidence: Installed tarball produces working bin shims</summary>

```text
$ npm pack && npm install --ignore-scripts astudioplus-codegraph-mcp-0.20.0.tgz
added 29 packages in 661ms

$ ls -l node_modules/.bin/ | grep codegraph
codegraph-daemon -> ../@astudioplus/codegraph-mcp/bin/codegraph-daemon.js
codegraph-mcp -> ../@astudioplus/codegraph-mcp/bin/codegraph-mcp.js
codegraph-mcp-fetch-engine -> ../@astudioplus/codegraph-mcp/bin/fetch-engine-cli.js
codegraph-mcp-install-hooks -> ../@astudioplus/codegraph-mcp/bin/install-hooks.js
```
</details>
<details>
<summary>Evidence: package-npm.sh happy path - live engine-asset verification against v0.20.0</summary>

<code>package.json version: 0.20.0&#10;server.json version: 0.20.0&#10;server.json npm package: 0.20.0&#10;&#10;engine version: 0.20.0 (fetched at install time)&#10;Checking published engine assets for v0.20.0...&#10;✓ codegraph-server-darwin-arm64&#10;✓ codegraph-server-darwin-x64&#10;✓ codegraph-server-linux-x64&#10;✓ codegraph-server-win32-x64.exe&#10;✓ onnxruntime.dll&#10;✓ every engine asset is published for v0.20.0&#10;&#10;✓ Created: mcp-package/astudioplus-codegraph-mcp-0.20.0.tgz ( 24K)</code>

```text
=== CodeGraph npm package builder ===

Removing any bundled binaries (the engine is fetched at install time)...

Checking the engine fetch and the wrapper arguments...
  ✓ package tests pass

package.json version:      0.20.0
server.json version:       0.20.0
server.json npm package:   0.20.0

engine version:            0.20.0 (fetched at install time)
Checking published engine assets for v0.20.0...
  ✓ codegraph-server-darwin-arm64
  ✓ codegraph-server-darwin-x64
  ✓ codegraph-server-linux-x64
  ✓ codegraph-server-win32-x64.exe
  ✓ onnxruntime.dll
  ✓ every engine asset is published for v0.20.0

Packing...
npm notice
npm notice 📦  @astudioplus/codegraph-mcp@0.20.0
npm notice Tarball Contents
npm notice 7.3kB README.md
npm notice 6.0kB bin/codegraph-daemon.js
npm notice 11.5kB bin/codegraph-mcp.js
npm notice 1.9kB bin/fetch-engine-cli.js
npm notice 17.0kB bin/fetch-engine.js
npm notice 8.6kB bin/install-hooks.js
npm notice 5.9kB bin/postinstall.js
npm notice 4.6kB hooks/codegraph-pre-edit.ps1
npm notice 3.9kB hooks/codegraph-pre-edit.sh
npm notice 1.2kB package.json
npm notice 606B server.json
npm notice Tarball Details
npm notice name: @astudioplus/codegraph-mcp
npm notice version: 0.20.0
npm notice filename: astudioplus-codegraph-mcp-0.20.0.tgz
npm notice package size: 22.2 kB
npm notice unpacked size: 68.5 kB
npm notice shasum: e0bfca866c1cedf446f6a2e06d1786b38da8b49e
npm notice integrity: sha512-/X6vyxOPv4VLc[...]BQ8pob73ipfFw==
npm notice total files: 11
npm notice
astudioplus-codegraph-mcp-0.20.0.tgz

✓ Created: mcp-package/astudioplus-codegraph-mcp-0.20.0.tgz ( 24K)

To publish: cd mcp-package && npm publish --access public
Then update MCP Registry: mcp-publisher publish --server-json server.json
```
</details>
<details>
<summary>Evidence: Gate exit codes: new script aborts where the base script warned and continued</summary>

<code># target commit (18c36df)&#10;happy path -&gt; exit 0&#10;server.json version mismatch -&gt; exit 1&#10;packages[].version mismatch -&gt; exit 1&#10;engine assets not published -&gt; exit 1&#10;&#10;# base commit (284c8e5), same server.json version mismatch&#10;package.json version: 0.20.0&#10;server.json version: 0.19.9&#10;WARNING: version mismatch between package.json and server.json&#10;Packing...&#10;✓ Created: mcp-package/astudioplus-codegraph-mcp-0.20.0.tgz ( 24K)&#10;base script exit with version mismatch -&gt; 0 (packaging proceeded)</code>

```text
# package-npm.sh gate exit codes (was: printed WARNING and continued)
happy path                       -> exit 0
server.json version mismatch     -> exit 1
packages[].version mismatch      -> exit 1
engine assets not published      -> exit 1

# same three cases on the base commit's script (284c8e5)
```
</details>
<details>
<summary>Evidence: Base-script behavior on version mismatch (full transcript)</summary>

```text
# BASE (284c8e5) script, same server.json version mismatch:
package.json version: 0.20.0
server.json version:  0.19.9
WARNING: version mismatch between package.json and server.json
Packing...
npm notice version: 0.20.0
✓ Created: mcp-package/astudioplus-codegraph-mcp-0.20.0.tgz ( 24K)
To publish: cd mcp-package && npm publish --access public
base script exit -> 
base script exit with version mismatch -> 0 (packaging proceeded)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `scripts/package-npm.sh:66` - The newly-fatal version check compares package.json.version only against server.json&#39;s top-level `version`, but the MCP Registry resolves the npm tarball from `packages[0].version` (mcp-package/server.json:14), which is left unchecked. Failing sequence: a release bumps mcp-package/package.json and server.json&#39;s top-level `version` to 0.21.0 but misses `packages[0].version` (still 0.20.0) - no script syncs these three fields, they are hand-edited. The gate passes, npm publishes 0.21.0, and `mcp-publisher publish` (line 106) registers a 0.21.0 server entry that points MCP clients at the 0.20.0 npm tarball. Registry validation still succeeds because that older tarball exists and carries the right mcpName, so the mismatch is silent - and per the change&#39;s own comment it cannot be corrected by republishing the same version. This is the exact &#39;npmjs.com and the MCP Registry disagreeing about what this release is&#39; failure the fatal check was added to prevent. Fix: extend the comparison to `require(server.json).packages[0].version` (and error on it the same way) before packing.
- ⚠️ `scripts/package-npm.sh:76` - The new pre-publish engine-asset gate probes a single asset, codegraph-server-linux-x64.sha256, while fetch-engine.js:120-133 resolves four distinct assets (codegraph-server-darwin-arm64, codegraph-server-darwin-x64, codegraph-server-linux-x64, codegraph-server-win32-x64.exe) plus the onnxruntime.dll sidecar. A partially-populated release is reachable: scripts/publish-release-assets.sh:219 uploads every staged file in one `gh release upload` invocation, and under `set -euo pipefail` a mid-upload failure (network drop, rate limit) aborts the script with some assets already attached. If linux-x64 landed and darwin/win32 did not, re-running package-npm.sh --publish passes this probe and publishes the npm package; macOS and Windows users then 404 in bin/postinstall.js and get &#39;a package that installs cleanly and then has nothing to run&#39; - the precise outcome this gate was introduced to prevent. Fix: loop the probe over the same asset list publish-release-assets.sh:43-46 defines, failing on the first missing one.
- ℹ️ `scripts/package-npm.sh:71` - The new comment states &#39;every install fetches one from the release tagged with this version&#39;, which reads as the package version being published. mcp-package/bin/fetch-engine.js:64-77 documents the opposite as deliberate: ENGINE_VERSION is intentionally decoupled from the client version so a client-only patch release does not request a tag that was never published. The code below is correct (it reads ENGINE_VERSION, not PKG_VERSION); only the comment is misleading, and it could prompt a future maintainer to &#39;fix&#39; the check to use PKG_VERSION and break client-only patch releases. Reword to name the pinned engine version explicitly.

🔧 Fix: harden npm packaging version and engine-asset gates
1 info still open:
- ℹ️ `scripts/package-npm.sh:124` - The asset gate now issues 10 sequential unauthenticated curl requests (5 assets x binary + .sha256) with no `--retry`, so a single transient failure - DNS blip, CDN 5xx, dropped connection - marks the asset missing and aborts with `ERROR: the release v${ENGINE_VERSION} is missing engine assets`, which asserts something untrue and points the operator at `publish-release-assets.sh --publish` for a release that is in fact complete. Behaviour is fail-closed and the operator can simply re-run, so impact is limited to a misleading message; the flake surface is however 10x what the single-probe version had. Adding `--retry 3 --retry-connrefused` (and optionally `--max-time`) to both probes would keep the gate strict while making a reported miss actually mean a miss. Verified read-only against the live v0.20.0 release that all 10 URLs currently return 206, so the stricter gate does not block the pending republish and the `-r 0-0` range request is honoured through GitHub&#39;s asset-CDN redirect.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd mcp-package &amp;&amp; npm test` (fetch-engine + wrapper-args suites, 0 failures)</code>
- <code>`npm publish --dry-run` in mcp-package with the fixed package.json - zero warn lines</code>
- <code>`npm publish --dry-run` on a temp copy with `git show 284c8e5:mcp-package/package.json` - reproduces the 5 auto-correction warnings</code>
- <code>`npm pkg fix` diff on the base package.json - shows npm rewriting the 4 `./bin/...` entries and repository.url</code>
- <code>`npm pack` the fixed package, then `npm install --ignore-scripts &lt;tarball&gt;` in a scratch project and inspect `node_modules/.bin/` shim targets</code>
- <code>`npm view @astudioplus/codegraph-mcp@0.20.0 bin repository.url` compared against the committed mcp-package/package.json</code>
- <code>`./scripts/package-npm.sh` happy path in a temp repo copy - live engine-asset probe against the v0.20.0 release, exit 0</code>
- <code>`./scripts/package-npm.sh` with server.json top-level version set to 0.19.9 - exit 1</code>
- <code>`./scripts/package-npm.sh` with server.json packages[0].version set to 0.19.9 - exit 1</code>
- <code>`./scripts/package-npm.sh` with fetch-engine.js ENGINE_VERSION set to 99.99.99 - all 5 assets reported missing, exit 1</code>
- <code>base-commit `scripts/package-npm.sh` with the same version mismatch - WARNING printed, packaging proceeded, exit 0</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `CHANGELOG.md:7` - Out-of-scope follow-up: CHANGELOG.md&#39;s newest entry is 0.17.0 while the shipped version is 0.20.0 (mcp-package/package.json, server.json, and bin/fetch-engine.js ENGINE_VERSION all read 0.20.0). This gap predates this change and this change is release-tooling only with no user-facing behavior, so no entry is owed here. Flagging it because a release-metadata commit is where the drift becomes visible; backfilling 0.18-0.20 deserves its own change.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `scripts/package-npm.sh:95` - shellcheck/shfmt are not installed and the repo configures no shell linter, so static analysis of the ~80 added lines in scripts/package-npm.sh was limited to `bash -n` syntax checking plus manual review. Manual review found no quoting, word-splitting, or set -euo pipefail interaction problems in the added code. If shell static analysis matters for release scripts, adding shellcheck to the toolchain would be a reasonable follow-up.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
