### PR TITLE
fix: prevent aarch64 startup crash and cross-file doc chunk id collisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "codegraph-harness"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "codegraph-memory"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "codegraph-server"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "clap",
  "codegraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/codegraph-ai/codegraph"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The server indexes the current working directory automatically.
 Install the VSIX:
 
 ```bash
-code --install-extension codegraph-0.20.0.vsix
+code --install-extension codegraph-0.20.1.vsix
 ```
 
 One VSIX serves every platform.

--- a/crates/codegraph-memory/src/docs.rs
+++ b/crates/codegraph-memory/src/docs.rs
@@ -94,6 +94,45 @@ impl HeadingNode {
     }
 }
 
+/// Stable 64-bit FNV-1a over a source path.
+///
+/// Deliberately not `DefaultHasher`: this value is baked into a persisted
+/// RocksDB key, and `DefaultHasher`'s output is explicitly not guaranteed
+/// stable across Rust releases. A toolchain upgrade would silently start
+/// minting different ids for the same file. FNV-1a is a handful of lines,
+/// so it costs no dependency and cannot change under us.
+fn source_hash(source_file: &str) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = FNV_OFFSET;
+    for byte in source_file.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+/// Build a chunk id that is unique across *sources*, not just within one.
+///
+/// The id is the RocksDB key (`doc:{id}` and `docvec:{id}`), the
+/// `chunk_cache` key, and the HNSW point id - all of which are a single
+/// global namespace. A bare per-file counter therefore minted `doc-0001`
+/// for every document, so indexing a second file wrote straight over the
+/// first one's chunks: they vanished from `list_doc_sources` and
+/// `search_docs` while indexing still reported success.
+///
+/// Loss was partial and size-dependent, which is what made it look
+/// intermittent: a 3-chunk file overwrote only the first 3 chunks of a
+/// 10-chunk file, and the 7 survivors then made `remove_source` look like
+/// it had done its job on the next re-index.
+///
+/// The counter keeps `{:04}` for readability but is not truncated to it -
+/// a document with more than 9999 chunks simply produces wider ids, which
+/// stay unique.
+fn chunk_id(source_file: &str, counter: u32) -> String {
+    format!("doc-{:016x}-{:04}", source_hash(source_file), counter)
+}
+
 /// Parse a markdown string into a flat list of `DocChunk`s by:
 ///
 /// 1. Building a heading tree from `#`…`######` markers.
@@ -221,7 +260,7 @@ fn collect_leaf_chunks(
         if word_count <= max_chunk_words {
             *counter += 1;
             out.push(DocChunk {
-                id: format!("doc-{:04}", counter),
+                id: chunk_id(source_file, *counter),
                 source_file: source_file.to_string(),
                 heading_path: path.clone(),
                 title: node.title.clone(),
@@ -235,7 +274,7 @@ fn collect_leaf_chunks(
             for para in paragraphs {
                 *counter += 1;
                 out.push(DocChunk {
-                    id: format!("doc-{:04}", counter),
+                    id: chunk_id(source_file, *counter),
                     source_file: source_file.to_string(),
                     heading_path: path.clone(),
                     title: node.title.clone(),
@@ -254,7 +293,7 @@ fn collect_leaf_chunks(
         if !preamble.is_empty() && preamble.split_whitespace().count() > 10 {
             *counter += 1;
             out.push(DocChunk {
-                id: format!("doc-{:04}", counter),
+                id: chunk_id(source_file, *counter),
                 source_file: source_file.to_string(),
                 heading_path: path.clone(),
                 title: format!("{} (overview)", node.title),
@@ -753,6 +792,76 @@ Details B.
         for c in &chunks {
             assert_eq!(c.heading_path, vec!["Section"]);
         }
+    }
+
+    /// The regression behind issue #16. Chunk ids are the RocksDB key, the
+    /// cache key and the HNSW point id, so two sources minting the same id
+    /// meant the second document silently overwrote the first.
+    #[test]
+    fn chunk_ids_do_not_collide_across_sources() {
+        let a = parse_markdown("# Alpha\n\nunique-alpha-marker\n", "/tmp/a.md", 500);
+        let b = parse_markdown("# Beta\n\nunique-beta-marker\n", "/tmp/b.md", 500);
+        assert!(!a.is_empty() && !b.is_empty(), "both docs should chunk");
+
+        for chunk_a in &a {
+            for chunk_b in &b {
+                assert_ne!(
+                    chunk_a.id, chunk_b.id,
+                    "ids from different sources must not collide: {} vs {}",
+                    chunk_a.source_file, chunk_b.source_file
+                );
+            }
+        }
+    }
+
+    /// Uniqueness must not come at the cost of stability: `remove_source`
+    /// and re-indexing rely on the same file producing the same ids, and
+    /// the ids are persisted, so they must survive a restart unchanged.
+    #[test]
+    fn chunk_ids_are_stable_for_the_same_source() {
+        let md = "# Alpha\n\n## One\nbody one\n\n## Two\nbody two\n";
+        let first = parse_markdown(md, "/tmp/a.md", 500);
+        let second = parse_markdown(md, "/tmp/a.md", 500);
+
+        let first_ids: Vec<&str> = first.iter().map(|c| c.id.as_str()).collect();
+        let second_ids: Vec<&str> = second.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(first_ids, second_ids);
+    }
+
+    /// A many-chunk document must not collide with a few-chunk one on the
+    /// low counter values. This is the shape that made the loss look
+    /// intermittent: only the first N chunks of the larger file were taken.
+    #[test]
+    fn large_and_small_sources_do_not_share_low_counters() {
+        let big: String = (1..=12)
+            .map(|i| format!("## Section {}\nbody {}\n\n", i, i))
+            .collect();
+        let big_chunks = parse_markdown(&big, "/tmp/big.md", 500);
+        let small_chunks = parse_markdown("## Only\nbody\n", "/tmp/small.md", 500);
+
+        assert!(
+            big_chunks.len() > small_chunks.len(),
+            "sanity: sizes differ"
+        );
+        let big_ids: std::collections::HashSet<&str> =
+            big_chunks.iter().map(|c| c.id.as_str()).collect();
+        for chunk in &small_chunks {
+            assert!(
+                !big_ids.contains(chunk.id.as_str()),
+                "small doc id {} collides with the large doc",
+                chunk.id
+            );
+        }
+    }
+
+    /// The hash is persisted inside every chunk id, so a change to it
+    /// orphans every chunk already on disk. Pin the values.
+    #[test]
+    fn source_hash_is_the_pinned_fnv1a() {
+        // FNV-1a/64 reference vectors.
+        assert_eq!(source_hash(""), 0xcbf2_9ce4_8422_2325);
+        assert_eq!(source_hash("a"), 0xaf63_dc4c_8601_ec8c);
+        assert_eq!(source_hash("foobar"), 0x8594_4171_f739_67e8);
     }
 
     #[test]

--- a/crates/codegraph-memory/tests/doc_multi_source.rs
+++ b/crates/codegraph-memory/tests/doc_multi_source.rs
@@ -1,0 +1,155 @@
+// Copyright 2025-2026 Andrey Vasilevsky <anvanster@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end regression test for issue #16.
+//!
+//! The unit tests in `docs.rs` prove that chunk ids differ between sources.
+//! This one proves the thing the user actually reported: indexing a second
+//! markdown file used to delete most of the first file's chunks from RocksDB,
+//! so `list_doc_sources` and `search_docs` stopped returning them - while
+//! indexing still reported success.
+//!
+//! It drives the real `DocStore`: real RocksDB keys, real embeddings, real
+//! HNSW search, and a reopen to confirm what survived on disk.
+//!
+//! Needs a local model2vec model directory, which is also what the
+//! `--embedding-model static` server path uses. Point `CODEGRAPH_STATIC_MODEL`
+//! at one, or have the default `~/.codegraph/static_models/jina-code-static-256`
+//! in place. The test skips (with a message) when no model is available rather
+//! than failing, since the model is not vendored in the repo.
+
+use codegraph_memory::{DocStore, VectorEngine};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn static_model_dir() -> Option<PathBuf> {
+    let dir = match std::env::var("CODEGRAPH_STATIC_MODEL") {
+        Ok(v) => PathBuf::from(v),
+        Err(_) => dirs_home()?
+            .join(".codegraph")
+            .join("static_models")
+            .join("jina-code-static-256"),
+    };
+    dir.join("model.safetensors").exists().then_some(dir)
+}
+
+fn dirs_home() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+/// Ten sections, so the document is comfortably larger than the second one.
+fn architecture_md() -> String {
+    let mut md = String::from("# Architecture Guide\n\n");
+    for i in 1..=10 {
+        md.push_str(&format!(
+            "## Subsystem {i}\n\nThe subsystem-{i} component owns marker-architecture-{i} and \
+             is responsible for coordinating work across the graph engine. It keeps its own \
+             state and reports progress to the supervisor.\n\n"
+        ));
+    }
+    md
+}
+
+/// Three sections - smaller than the guide above, which is what made the
+/// original data loss look intermittent.
+fn onboarding_md() -> String {
+    let mut md = String::from("# Onboarding Guide\n\n");
+    for i in 1..=3 {
+        md.push_str(&format!(
+            "## Step {i}\n\nFollow step-{i} to set up your workstation; marker-onboarding-{i} \
+             covers the tools you need before your first change lands.\n\n"
+        ));
+    }
+    md
+}
+
+#[test]
+fn indexing_a_second_source_does_not_evict_the_first() {
+    let Some(model_dir) = static_model_dir() else {
+        eprintln!("skipping: no static embedding model available (set CODEGRAPH_STATIC_MODEL)");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let arch_path = tmp.path().join("architecture.md");
+    let onboard_path = tmp.path().join("onboarding.md");
+    std::fs::write(&arch_path, architecture_md()).expect("write architecture.md");
+    std::fs::write(&onboard_path, onboarding_md()).expect("write onboarding.md");
+
+    let engine = Arc::new(VectorEngine::with_static_model(&model_dir).expect("static engine"));
+    let db_path = tmp.path().join("docs.db");
+
+    let arch_indexed;
+    let onboard_indexed;
+    {
+        let store = DocStore::new(&db_path, Arc::clone(&engine)).expect("open store");
+        arch_indexed = store
+            .index_file(&arch_path, 500)
+            .expect("index architecture.md")
+            .len();
+        onboard_indexed = store
+            .index_file(&onboard_path, 500)
+            .expect("index onboarding.md")
+            .len();
+
+        assert!(arch_indexed > onboard_indexed, "sanity: sizes differ");
+        println!("indexed architecture.md -> {arch_indexed} chunks");
+        println!("indexed onboarding.md   -> {onboard_indexed} chunks");
+
+        let sources = store.list_sources();
+        println!("list_doc_sources        -> {} source(s)", sources.len());
+        assert_eq!(sources.len(), 2, "both sources must be listed: {sources:?}");
+
+        // The first file must still have every chunk it was indexed with.
+        let arch_source = arch_path.to_string_lossy().to_string();
+        let arch_stored = store.get_chunks_by_source(&arch_source).len();
+        println!("chunks still stored for architecture.md -> {arch_stored}");
+        assert_eq!(
+            arch_stored, arch_indexed,
+            "indexing the second file must not drop chunks from the first"
+        );
+
+        // And it must still be findable, which is the user-visible symptom.
+        let hits = store.search("marker-architecture-7 subsystem", 3).expect("search");
+        for hit in &hits {
+            let file = std::path::Path::new(&hit.chunk.source_file);
+            println!(
+                "search_docs hit         -> {} § {} ({:.2})",
+                file.file_name().unwrap_or_default().to_string_lossy(),
+                hit.chunk.title,
+                hit.score
+            );
+        }
+        assert!(
+            hits.iter().any(|h| h.chunk.source_file == arch_source),
+            "search must still reach the first document"
+        );
+    }
+
+    // Reopen: chunk ids are RocksDB keys, so a collision would show up as
+    // missing rows after a restart too.
+    let store = DocStore::new(&db_path, engine).expect("reopen store");
+    println!(
+        "after reopen            -> {} source(s), architecture.md {} chunks, onboarding.md {} chunks",
+        store.list_sources().len(),
+        store.get_chunks_by_source(&arch_path.to_string_lossy()).len(),
+        store
+            .get_chunks_by_source(&onboard_path.to_string_lossy())
+            .len(),
+    );
+    assert_eq!(store.list_sources().len(), 2, "both sources survive a reopen");
+    assert_eq!(
+        store
+            .get_chunks_by_source(&arch_path.to_string_lossy())
+            .len(),
+        arch_indexed,
+        "first document survives a reopen intact"
+    );
+    assert_eq!(
+        store
+            .get_chunks_by_source(&onboard_path.to_string_lossy())
+            .len(),
+        onboard_indexed,
+        "second document survives a reopen intact"
+    );
+}

--- a/crates/codegraph-server/src/glibc_compat.rs
+++ b/crates/codegraph-server/src/glibc_compat.rs
@@ -34,6 +34,13 @@ pub struct SingleThreaded(UnsafeCell<u8>);
 
 impl SingleThreaded {
     /// The initial value of the flag: "not single threaded".
+    ///
+    /// `declare_interior_mutable_const` warns because copying a const with
+    /// interior mutability normally gives each use its own hidden cell. That
+    /// is precisely the intent here: this const exists only to initialise the
+    /// `#[no_mangle] static` in each target, so there is exactly one cell per
+    /// target and nothing ever reads it through the const.
+    #[allow(clippy::declare_interior_mutable_const)]
     pub const ZERO: Self = Self(UnsafeCell::new(0));
 }
 

--- a/crates/codegraph-server/src/glibc_compat.rs
+++ b/crates/codegraph-server/src/glibc_compat.rs
@@ -1,0 +1,43 @@
+// Copyright 2025-2026 Andrey Vasilevsky <anvanster@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! glibc 2.31 compatibility storage for `__libc_single_threaded`.
+//!
+//! `__libc_single_threaded` was added in glibc 2.32 but ONNX Runtime
+//! references it, so a build for SLES 15 SP4 and similar needs a definition to
+//! link against. Every target that links ONNX Runtime - the binary and the
+//! test executables, which do not include `main.rs` - has to supply one.
+//!
+//! The storage must be WRITABLE. It was previously `pub static ...: u8 = 0`,
+//! which lands in .rodata, under a comment claiming "on newer glibc the real
+//! symbol shadows this at runtime" - the opposite of how ELF resolves it. A
+//! definition in the executable takes precedence over the one in libc, and on
+//! aarch64 this symbol is also emitted into .dynsym, so glibc bound its own
+//! startup write of the flag to the read-only byte and took SIGSEGV before
+//! `main()`: every invocation died, including `--version` and `--help`
+//! (issue #15). x86_64 escaped only because the symbol is not dynamically
+//! exported there, so glibc kept using its own copy.
+//!
+//! glibc owns the value: it sets the flag at startup and clears it when a
+//! thread is created. We only supply the storage, and never read it. On a
+//! glibc too old to maintain it, the byte stays 0, which is the conservative
+//! "not single threaded" answer.
+//!
+//! Every definition of the symbol must use [`SingleThreaded`] so the writable
+//! storage cannot drift back to a plain `u8` in one target and not another.
+
+use std::cell::UnsafeCell;
+
+/// Writable single-byte storage for glibc's `__libc_single_threaded` flag.
+#[repr(transparent)]
+pub struct SingleThreaded(UnsafeCell<u8>);
+
+impl SingleThreaded {
+    /// The initial value of the flag: "not single threaded".
+    pub const ZERO: Self = Self(UnsafeCell::new(0));
+}
+
+// SAFETY: glibc is the only writer, from its own startup and thread-creation
+// paths, and this process never reads the byte. The UnsafeCell is what places
+// it in writable memory rather than .rodata.
+unsafe impl Sync for SingleThreaded {}

--- a/crates/codegraph-server/src/lib.rs
+++ b/crates/codegraph-server/src/lib.rs
@@ -12,15 +12,18 @@
 //! - **LSP** (default): Standard Language Server Protocol for IDE integration
 //! - **MCP** (`--mcp` flag): Model Context Protocol for AI client integration
 
-// glibc 2.31 compat (test builds): the production shim lives in main.rs
-// for the binary target. `cargo test --lib` builds a separate test
-// executable that doesn't include main.rs, so ONNX Runtime's reference
-// to `__libc_single_threaded` (added in glibc 2.32) goes unresolved
-// when linking tests on SLES 15-SP4. This duplicate is gated on
-// `cfg(test)` so the binary target never sees two definitions.
+// glibc 2.31 compat (test builds): the production shim lives in main.rs for
+// the binary target. `cargo test --lib` builds a separate test executable that
+// doesn't include main.rs, so ONNX Runtime's reference to
+// `__libc_single_threaded` (added in glibc 2.32) goes unresolved when linking
+// tests on SLES 15-SP4. This definition is gated on `cfg(test)` so the binary
+// target never sees two of them; see `glibc_compat` for why the storage has to
+// be writable.
 #[cfg(all(target_os = "linux", test))]
 #[no_mangle]
-pub static __libc_single_threaded: u8 = 0;
+#[allow(non_upper_case_globals)]
+pub static __libc_single_threaded: glibc_compat::SingleThreaded =
+    glibc_compat::SingleThreaded::ZERO;
 
 pub mod ai_query;
 pub mod backend;
@@ -33,6 +36,7 @@ pub mod domain;
 pub mod embed_queue;
 pub mod error;
 pub mod git_mining;
+pub mod glibc_compat;
 pub mod handlers;
 pub mod index;
 pub mod index_state;

--- a/crates/codegraph-server/src/main.rs
+++ b/crates/codegraph-server/src/main.rs
@@ -14,11 +14,38 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 // glibc 2.31 compat: __libc_single_threaded was added in glibc 2.32 but ONNX
-// Runtime references it. Provide a fallback for SLES 15 SP4 and similar.
-// On newer glibc the real symbol shadows this at runtime.
+// Runtime references it, so a build for SLES 15 SP4 and similar needs a
+// definition to link against.
+//
+// The storage must be WRITABLE. This was previously `pub static ... : u8 = 0`,
+// which lands in .rodata, and the comment claimed "on newer glibc the real
+// symbol shadows this at runtime" - the opposite of how ELF resolves it. A
+// definition in the executable takes precedence over the one in libc, and on
+// aarch64 this symbol is also emitted into .dynsym, so glibc bound its own
+// startup write of the flag to our read-only byte and took SIGSEGV before
+// main(): every invocation died, including `--version` and `--help`
+// (issue #15). x86_64 escaped only because the symbol is not dynamically
+// exported there, so glibc kept using its own copy.
+//
+// glibc owns the value: it sets the flag at startup and clears it when a
+// thread is created. We only supply the storage, and never read it. On a glibc
+// too old to maintain it, the byte stays 0, which is the conservative
+// "not single threaded" answer.
 #[cfg(target_os = "linux")]
-#[no_mangle]
-pub static __libc_single_threaded: u8 = 0;
+mod glibc_compat {
+    use std::cell::UnsafeCell;
+
+    #[repr(transparent)]
+    pub struct SingleThreaded(UnsafeCell<u8>);
+
+    // SAFETY: glibc is the only writer, from its own startup and
+    // thread-creation paths, and this process never reads the byte. The
+    // UnsafeCell is what places it in writable memory rather than .rodata.
+    unsafe impl Sync for SingleThreaded {}
+
+    #[no_mangle]
+    pub static __libc_single_threaded: SingleThreaded = SingleThreaded(UnsafeCell::new(0));
+}
 
 #[derive(Parser)]
 #[command(name = "codegraph-server")]

--- a/crates/codegraph-server/src/main.rs
+++ b/crates/codegraph-server/src/main.rs
@@ -13,39 +13,16 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-// glibc 2.31 compat: __libc_single_threaded was added in glibc 2.32 but ONNX
-// Runtime references it, so a build for SLES 15 SP4 and similar needs a
-// definition to link against.
-//
-// The storage must be WRITABLE. This was previously `pub static ... : u8 = 0`,
-// which lands in .rodata, and the comment claimed "on newer glibc the real
-// symbol shadows this at runtime" - the opposite of how ELF resolves it. A
-// definition in the executable takes precedence over the one in libc, and on
-// aarch64 this symbol is also emitted into .dynsym, so glibc bound its own
-// startup write of the flag to our read-only byte and took SIGSEGV before
-// main(): every invocation died, including `--version` and `--help`
-// (issue #15). x86_64 escaped only because the symbol is not dynamically
-// exported there, so glibc kept using its own copy.
-//
-// glibc owns the value: it sets the flag at startup and clears it when a
-// thread is created. We only supply the storage, and never read it. On a glibc
-// too old to maintain it, the byte stays 0, which is the conservative
-// "not single threaded" answer.
+// glibc 2.31 compat: ONNX Runtime references `__libc_single_threaded`, which
+// glibc only defines from 2.32 on, so a build for SLES 15 SP4 and similar
+// needs a definition to link against. The storage has to be writable - glibc
+// writes the flag at startup - which is what `SingleThreaded` provides; see
+// `codegraph_server::glibc_compat` for the full story (issue #15).
 #[cfg(target_os = "linux")]
-mod glibc_compat {
-    use std::cell::UnsafeCell;
-
-    #[repr(transparent)]
-    pub struct SingleThreaded(UnsafeCell<u8>);
-
-    // SAFETY: glibc is the only writer, from its own startup and
-    // thread-creation paths, and this process never reads the byte. The
-    // UnsafeCell is what places it in writable memory rather than .rodata.
-    unsafe impl Sync for SingleThreaded {}
-
-    #[no_mangle]
-    pub static __libc_single_threaded: SingleThreaded = SingleThreaded(UnsafeCell::new(0));
-}
+#[no_mangle]
+#[allow(non_upper_case_globals)]
+pub static __libc_single_threaded: codegraph_server::glibc_compat::SingleThreaded =
+    codegraph_server::glibc_compat::SingleThreaded::ZERO;
 
 #[derive(Parser)]
 #[command(name = "codegraph-server")]

--- a/jetbrains/gradle.properties
+++ b/jetbrains/gradle.properties
@@ -5,7 +5,7 @@
 # clients. The engine it fetches is pinned separately, in
 # CodeGraphServerResolver.ENGINE_VERSION, so a plugin-only patch cannot start
 # asking the release server for a tag that was never published.
-pluginVersion=0.20.0
+pluginVersion=0.20.1
 
 # Target platform. 243 = 2024.3, the oldest build LSP4IJ 0.20.x supports that
 # also has a stable Code Vision API. Bumping this is a compatibility decision,

--- a/jetbrains/src/main/kotlin/ai/codegraph/jetbrains/server/CodeGraphServerResolver.kt
+++ b/jetbrains/src/main/kotlin/ai/codegraph/jetbrains/server/CodeGraphServerResolver.kt
@@ -301,7 +301,7 @@ object CodeGraphServerResolver {
      * held equal to Cargo.toml by `scripts/publish-release-assets.sh`, which
      * refuses to publish while they disagree.
      */
-    const val ENGINE_VERSION = "0.20.0"
+    const val ENGINE_VERSION = "0.20.1"
 
     private val ARM64_ARCHES = setOf("aarch64", "arm64")
     private val X64_ARCHES = setOf("x86_64", "amd64", "x64")

--- a/mcp-package/bin/fetch-engine.js
+++ b/mcp-package/bin/fetch-engine.js
@@ -75,7 +75,7 @@ const RELEASE_BASE = "https://github.com/codegraph-ai/CodeGraph/releases/downloa
  * Kept equal to the engine version by `scripts/publish-release-assets.sh`, which
  * refuses to publish while any channel's pin disagrees with Cargo.toml.
  */
-const ENGINE_VERSION = "0.20.0";
+const ENGINE_VERSION = "0.20.1";
 
 /** Codes Windows and POSIX use for "something else has this file open". */
 const IN_USE_ERROR_CODES = new Set(["EPERM", "EACCES", "EBUSY", "ETXTBSY"]);

--- a/mcp-package/package.json
+++ b/mcp-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astudioplus/codegraph-mcp",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "mcpName": "io.github.codegraph-ai/codegraph",
   "description": "CodeGraph MCP server \u2014 cross-language code intelligence with 42 tools, 38 languages",
   "author": "Andrey Vasilevsky <anvanster@gmail.com>",

--- a/mcp-package/server.json
+++ b/mcp-package/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/codegraph-ai/CodeGraph",
     "source": "github"
   },
-  "version": "0.20.0",
+  "version": "0.20.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@astudioplus/codegraph-mcp",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "transport": {
         "type": "stdio"
       },

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -30,7 +30,7 @@ The server indexes the current working directory automatically.
 Install from the marketplace, or sideload the VSIX:
 
 ```bash
-code --install-extension codegraph-0.20.0.vsix
+code --install-extension codegraph-0.20.1.vsix
 ```
 
 One VSIX serves every platform.

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "codegraph",
     "displayName": "CodeGraph",
     "description": "Cross-language code intelligence powered by graph analysis",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "publisher": "aStudioPlus",
     "author": "Andrey Vasilevsky <anvanster@gmail.com>",
     "license": "Apache-2.0",


### PR DESCRIPTION
## Intent

The developer asked the agent to triage two newly filed GitHub issues against the CodeGraph repo and then fix them: issue #16, where markdown doc chunk IDs were minted from a per-file counter so indexing a second markdown file silently overwrote the first file's chunks in RocksDB and the vector store, and issue #15, an aarch64 Linux SIGSEGV at startup. They explicitly required that #15 be reproduced on their arm64 Ubuntu OrbStack VM rather than diagnosed from theory, and after seeing the reproduction and root cause (the `__libc_single_threaded` glibc shim declared as an immutable static landing in read-only memory and being dynamically exported on aarch64), they authorized applying that fix and committing the #16 fix. They then asked to bump the version, commit, and push, with pushes going through the no-mistakes gate rather than directly to origin, and with CHANGELOG.md left untouched per their standing rule against hand-editing generated files. Earlier in the same session they had also insisted the already-published npm 0.20.0 must not be republished or renumbered, which framed this as a follow-on 0.20.1 patch release carrying the two issue fixes.

## What Changed

- Moved the `__libc_single_threaded` glibc 2.31 shim into a new `codegraph-server::glibc_compat` module that backs the symbol with a writable `UnsafeCell<u8>` (`SingleThreaded::ZERO`) instead of an immutable `static u8` in `.rodata`. Both the binary target (`main.rs`) and the `cfg(test)` definition in `lib.rs` now share that storage, so glibc's startup write to the flag no longer faults - previously every invocation on aarch64 Linux, including `--version`, died with SIGSEGV before `main()` because the executable's read-only definition took precedence over libc's via `.dynsym` (issue #15).
- Doc chunk ids are now namespaced by source file: `chunk_id()` prefixes the per-file counter with a pinned 64-bit FNV-1a hash of the source path (`doc-{hash:016x}-{counter:04}`), replacing the bare `doc-{counter:04}` that made every document reuse the same global RocksDB/`chunk_cache`/HNSW keys and silently overwrite earlier files' chunks (issue #16). FNV-1a is used deliberately over `DefaultHasher`, whose output is not stable across Rust releases, since the hash is baked into persisted keys.
- Added unit tests for cross-source id uniqueness, per-source id stability, large-vs-small document counter overlap, and the pinned FNV-1a vectors, plus a `doc_multi_source` integration test exercising multi-file indexing through DocStore. Bumped the workspace, mcp-package, VS Code, and JetBrains version strings to 0.20.1 and synced the VSIX install example in both READMEs.

## Risk Assessment

✅ Low: The follow-up commit resolves the previously reported sibling defect at the right boundary - both the binary and the `cfg(test)` lib definition now share the single `SingleThreaded(UnsafeCell&lt;u8&gt;)` newtype, whose non-`Freeze` type is what forces writable `.data` placement, and the two definitions remain mutually exclusive per build target so no target sees zero or two of them; the rest of the branch (source-namespaced doc chunk ids, consistent 0.20.1 pins) was verified clean in the prior pass.

## Testing

Ran the docs unit tests in codegraph-memory (all 14 pass, including the four new id-collision/stability tests), then wrote and ran a new end-to-end integration test that indexes two markdown files through the real RocksDB-backed DocStore and reopens it - it fails on the base commit's docs.rs with 7 of 10 chunks silently evicted and passes on the branch with both documents intact and searchable. For the aarch64 startup crash I built the pre-fix and post-fix shim variants inside an aarch64 Linux glibc container and captured ELF section placement plus actual process exit status: read-only .rodata shim SIGSEGVs before main(), the writable SingleThreaded shim reaches main(); the same comparison was repeated for the cfg(test) shim form. No UI surface is involved in this change, so the reviewer-visible evidence is CLI transcripts rather than screenshots. Transient repro binaries and the pulled container image were removed; the only working-tree change left is the new test file.

<details>
<summary>Evidence: Issue #15 - aarch64 Linux before/after reproduction (SIGSEGV vs clean start)</summary>

<code>=== aarch64 Linux reproduction of issue #15 (codegraph-server SIGSEGV at startup) ===&#10;host: Linux 6.19.13-orbstack-gbd1dc07b8cf4 aarch64&#10;libc: ldd (Debian GLIBC 2.41-12+deb13u3) 2.41&#10;rustc: rustc 1.97.1 (8bab26f4f 2026-07-14)&#10;&#10;--- BEFORE fix - pub static __libc_single_threaded: u8 = 0 ---&#10;symbol : 70: 000000000003aac9 1 OBJECT GLOBAL DEFAULT 14 __libc_single_threaded&#10;section: .rodata (flags: A)&#10;exported in .dynsym: 1 entry&#10;run : KILLED, exit=139 (SIGSEGV) - never reached main()&#10;&#10;--- AFTER fix - glibc_compat::SingleThreaded (UnsafeCell&lt;u8&gt;) ---&#10;symbol : 70: 00000000000609b9 1 OBJECT GLOBAL DEFAULT 27 __libc_single_threaded&#10;section: .bss (flags: WA)&#10;exported in .dynsym: 1 entry&#10;run : codegraph-server 0.20.1 (main() reached) [exit 0]</code>

```text
=== aarch64 Linux reproduction of issue #15 (codegraph-server SIGSEGV at startup) ===
host: Linux 6.19.13-orbstack-gbd1dc07b8cf4 aarch64
libc: ldd (Debian GLIBC 2.41-12+deb13u3) 2.41
rustc: rustc 1.97.1 (8bab26f4f 2026-07-14)

--- BEFORE fix - pub static __libc_single_threaded: u8 = 0 ---
    symbol : 70: 000000000003aac9     1 OBJECT  GLOBAL DEFAULT   14 __libc_single_threaded
    section: .rodata (flags: A)
    exported in .dynsym: 1 entry
    run    : KILLED, exit=139 (SIGSEGV) - never reached main()

--- AFTER fix  - glibc_compat::SingleThreaded (UnsafeCell<u8>) ---
    symbol : 70: 00000000000609b9     1 OBJECT  GLOBAL DEFAULT   27 __libc_single_threaded
    section: .bss (flags: WA)
    exported in .dynsym: 1 entry
    run    : codegraph-server 0.20.1 (main() reached)  [exit 0]
```
</details>
<details>
<summary>Evidence: Issue #16 - second markdown file silently evicts the first (pre-fix docs.rs)</summary>

<code>running 1 test&#10;indexed architecture.md -&gt; 10 chunks&#10;indexed onboarding.md -&gt; 3 chunks&#10;list_doc_sources -&gt; 2 source(s)&#10;chunks still stored for architecture.md -&gt; 7&#10;&#10;thread &#39;indexing_a_second_source_does_not_evict_the_first&#39; panicked at crates/codegraph-memory/tests/doc_multi_source.rs:107:9:&#10;assertion `left == right` failed: indexing the second file must not drop chunks from the first&#10;left: 7&#10;right: 10&#10;test indexing_a_second_source_does_not_evict_the_first ... FAILED</code>

```text
   Compiling codegraph-memory v0.20.1 (/Users/anvanster/.no-mistakes/worktrees/b8216ba13cd2/01KZJF58SQZ239MEF2NKEABMCF/crates/codegraph-memory)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.91s
     Running tests/doc_multi_source.rs (target/debug/deps/doc_multi_source-0401732d95570382)

running 1 test
indexed architecture.md -> 10 chunks
indexed onboarding.md   -> 3 chunks
list_doc_sources        -> 2 source(s)
chunks still stored for architecture.md -> 7

thread 'indexing_a_second_source_does_not_evict_the_first' (47457249) panicked at crates/codegraph-memory/tests/doc_multi_source.rs:107:9:
assertion `left == right` failed: indexing the second file must not drop chunks from the first
  left: 7
 right: 10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test indexing_a_second_source_does_not_evict_the_first ... FAILED

failures:

failures:
    indexing_a_second_source_does_not_evict_the_first

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.95s

error: test failed, to rerun pass `-p codegraph-memory --test doc_multi_source`
```
</details>
<details>
<summary>Evidence: Issue #16 - both documents intact, searchable, and persisted after fix</summary>

<code>running 1 test&#10;indexed architecture.md -&gt; 10 chunks&#10;indexed onboarding.md -&gt; 3 chunks&#10;list_doc_sources -&gt; 2 source(s)&#10;chunks still stored for architecture.md -&gt; 10&#10;search_docs hit -&gt; architecture.md § Subsystem 7 (0.56)&#10;search_docs hit -&gt; architecture.md § Subsystem 8 (0.53)&#10;search_docs hit -&gt; architecture.md § Subsystem 9 (0.53)&#10;after reopen -&gt; 2 source(s), architecture.md 10 chunks, onboarding.md 3 chunks&#10;test indexing_a_second_source_does_not_evict_the_first ... ok&#10;&#10;test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out</code>

```text
   Compiling codegraph-memory v0.20.1 (/Users/anvanster/.no-mistakes/worktrees/b8216ba13cd2/01KZJF58SQZ239MEF2NKEABMCF/crates/codegraph-memory)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.53s
     Running tests/doc_multi_source.rs (target/debug/deps/doc_multi_source-0401732d95570382)

running 1 test
indexed architecture.md -> 10 chunks
indexed onboarding.md   -> 3 chunks
list_doc_sources        -> 2 source(s)
chunks still stored for architecture.md -> 10
search_docs hit         -> architecture.md § Subsystem 7 (0.56)
search_docs hit         -> architecture.md § Subsystem 8 (0.53)
search_docs hit         -> architecture.md § Subsystem 9 (0.53)
after reopen            -> 2 source(s), architecture.md 10 chunks, onboarding.md 3 chunks
test indexing_a_second_source_does_not_evict_the_first ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.96s
```
</details>
<details>
<summary>Evidence: Issue #15 - cfg(test) shim from lib.rs, aarch64 Linux (commit 6cbdde6)</summary>

<code># post-fix (glibc_compat::SingleThreaded)&#10;running 1 test&#10;test tests::test_executable_starts_with_the_shim_linked_in ... ok&#10;test result: ok. 1 passed; 0 failed&#10;&#10;# pre-fix (plain `pub static __libc_single_threaded: u8 = 0`)&#10;Segmentation fault&#10;exit=139</code>

```text

running 1 test
test tests::test_executable_starts_with_the_shim_linked_in ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

Segmentation fault
exit=139
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `crates/codegraph-server/src/lib.rs:23` - The `cfg(test)` copy of the glibc shim is still `#[no_mangle] pub static __libc_single_threaded: u8 = 0`, i.e. an immutable static that lands in .rodata - the exact defect just fixed in main.rs. The test executable links ONNX Runtime and exports the symbol the same way the binary does, so on aarch64 Linux the dynamic linker binds glibc&#39;s startup write of the flag to this read-only byte and the process dies with SIGSEGV before any test function runs. x86_64 CI (`.github/workflows/codegraph-pr.yml` runs on ubuntu-latest) never exercises it, so `cargo test -p codegraph-server --lib` on the arm64 Ubuntu VM used to reproduce issue #15 still crashes at startup. Fix at the same boundary as main.rs: give this definition writable storage (share the `SingleThreaded(UnsafeCell&lt;u8&gt;)` newtype rather than a second hand-rolled copy, so the invariant lives in one place for both the bin and the test target).

🔧 Fix: share writable glibc_single_threaded shim with test target
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cargo test -p codegraph-memory --lib docs::` - 14 passed, covering the new chunk-id uniqueness, stability and pinned-FNV-1a tests</code>
- <code>`cargo test -p codegraph-memory --test doc_multi_source -- --nocapture` - new end-to-end DocStore test (RocksDB persistence, semantic search, store reopen)</code>
- <code>Same test re-run with `git show 284c8e5:crates/codegraph-memory/src/docs.rs` swapped in - reproduces issue #16 data loss (7 of 10 chunks survive), then restored HEAD docs.rs</code>
- <code>aarch64 Linux repro in `docker run --platform linux/arm64 rust:1-slim-trixie` - built `main_before.rs` (pre-fix `pub static __libc_single_threaded: u8 = 0`) and `main_after.rs` (branch `glibc_compat::SingleThreaded`), inspected with `readelf -sW`/`readelf -SW`/`readelf --dyn-syms`, and ran both binaries</code>
- <code>`rustc --test` variant of the `cfg(all(target_os = &#34;linux&#34;, test))` shim from lib.rs, run on aarch64 Linux in both pre-fix and post-fix form</code>
- <code>`git diff 284c8e5..HEAD` over Cargo.toml, mcp-package/package.json, mcp-package/server.json, mcp-package/bin/fetch-engine.js, vscode/package.json, jetbrains/gradle.properties - version strings all move 0.20.0 -&gt; 0.20.1</code>

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `scripts/publish-release-assets.sh:76` - The release version is hand-copied into the VSIX install example in both README.md and vscode/README.md, but publish-release-assets.sh only pin-checks the ENGINE_VERSION constants and package/server.json. That is why both READMEs still said 0.20.0 after this bump (I fixed them). Follow-up worth doing outside this change: either extend the release script&#39;s pin check to the README install examples, or make the example version-agnostic (e.g. codegraph-&lt;version&gt;.vsix / a marketplace-only instruction) so it cannot go stale again.

</details>

<details>
<summary>⚠️ **Lint** - 3 infos</summary>

- ℹ️ `mcp-package/package-lock.json:3` - Pre-existing version drift this bump makes more visible: mcp-package/package-lock.json still records 0.17.1 and vscode/package-lock.json still records 0.15.0 for their own packages, while package.json is now 0.20.1. Not fixed here - lockfiles must be regenerated by npm rather than hand-edited, and doing so is outside a documentation/lint pass.
- ℹ️ `vscode/package.json:1797` - The `lint` script runs `eslint src --ext ts`, but vscode/ has no eslint config of any kind, so the script fails immediately under ESLint 9+ (&#34;couldn&#39;t find an eslint.config.js&#34;). Pre-existing and unrelated to this change (no TypeScript changed), and adding a flat config is a real configuration decision rather than a mechanical fix, so I left it.
- ℹ️ `crates/codegraph-memory/src/docs.rs:74` - The workspace is not `cargo fmt --all --check` clean, in files untouched by this change (e.g. crates/codegraph-c/src/visitor.rs, several pre-existing regions of crates/codegraph-memory/src/docs.rs). No rustfmt.toml and no CI fmt gate exist, so formatting is evidently not enforced; reformatting would add large unrelated churn to this patch, so I limited fmt review to the changed hunks (which are conforming).

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
