### PR TITLE
fix(installer): report the requested unsupported platform

### DIFF
--- a/mcp-package/bin/fetch-engine.js
+++ b/mcp-package/bin/fetch-engine.js
@@ -387,9 +387,10 @@ function isStale(targetDir, version) {
  *   and which assets were downloaded (empty when everything was already there).
  */
 async function ensureEngine(version, targetDir, options = {}) {
-  const assets = requiredAssets(options.platform, options.arch);
+  const { platform = os.platform(), arch = os.arch() } = options;
+  const assets = requiredAssets(platform, arch);
   if (assets.length === 0) {
-    throw new Error(`no CodeGraph engine is published for ${os.platform()}-${os.arch()}`);
+    throw new Error(`no CodeGraph engine is published for ${platform}-${arch}`);
   }
 
   fs.mkdirSync(targetDir, { recursive: true });

--- a/mcp-package/test/fetch-engine.test.js
+++ b/mcp-package/test/fetch-engine.test.js
@@ -474,6 +474,34 @@ async function run() {
   // someone else's binary.
   check(platformBinaryName("linux", "riscv64") === null, "an unbuilt arch resolves to nothing");
   check(requiredAssets("linux", "riscv64").length === 0, "an unpublished pair needs no assets");
+
+  // --- unsupported installs report the requested platform and arch -----
+  {
+    const dir = scratch();
+    const targetDir = path.join(dir, "engine");
+    const { server, baseUrl } = await startRelease({});
+    try {
+      for (const [options, target] of [
+        [{ platform: "freebsd", arch: "x64" }, "freebsd-x64"],
+        [{ platform: "linux", arch: "riscv64" }, "linux-riscv64"],
+        [{ platform: "win32", arch: "arm" }, "win32-arm"],
+        [{ platform: "freebsd" }, `freebsd-${os.arch()}`],
+        [{ arch: "riscv64" }, `${os.platform()}-riscv64`],
+      ]) {
+        let threw = null;
+        await ensureEngine(VERSION, targetDir, { ...options, baseUrl }).catch((e) => (threw = e));
+        check(
+          threw !== null && threw.message === `no CodeGraph engine is published for ${target}`,
+          `an unsupported install reports ${target}`
+        );
+        check(!fs.existsSync(targetDir), `${target} is rejected before creating the install directory`);
+      }
+    } finally {
+      server.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
   // Every name the mapping can return has to be a name the release publishes,
   // or an install fetches a 404.
   for (const [p, a] of [


### PR DESCRIPTION
When `ensureEngine()` receives an unsupported platform or architecture override, it selects assets using that override but reports the host platform in the error. For example, requesting `linux-riscv64` on Windows x64 reports `no CodeGraph engine is published for win32-x64`.

Resolve the platform and architecture once, using the existing defaults for omitted values, and use them for both asset selection and the error message. Add regression coverage for three unsupported pairs and each partial override, including rejection before the install directory is created.

Validation:

- Before the fix, the five new error-message assertions fail against `main` (`489ccf1`); the existing installer checks pass.
- After the fix, `npm test` in `mcp-package` exits successfully on Windows x64 with Node.js 24.10.0. All installer checks pass. The existing wrapper argument suite reports `SKIP` because its stub engine was not used on this host.
- `git diff --check` passes.
